### PR TITLE
Use null only when result is undefined

### DIFF
--- a/src/Server.coffee
+++ b/src/Server.coffee
@@ -112,7 +112,7 @@ class Server
     setSuccess = (result) ->
       response =
         jsonrpc: '2.0'
-        result: result || null
+        result: if typeof result != 'undefined' then result else null
         id: responseId
       callback response
 


### PR DESCRIPTION
The old behavior prevented the use of 0 or
empty string as result, by converting them to
null.

Signed-off-by: Alexandre Bard <alexandre.bard@netmodule.com>